### PR TITLE
feat: address transactions + gas usage meters

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -260,6 +260,7 @@ function App(props: any) {
               <Route path={"/blocks/:number"} component={NodeView} />
               <Route path={"/tx/:hash/raw"} component={TransactionRawContainer} />
               <Route path={"/tx/:hash"} component={Transaction} />
+              <Route path={"/address/:address/:block"} component={Address} />
               <Route path={"/address/:address"} component={Address} />
             </Switch>
           </QueryParamProvider>

--- a/src/components/AddressTransactions/AddressTransactions.tsx
+++ b/src/components/AddressTransactions/AddressTransactions.tsx
@@ -1,0 +1,43 @@
+import * as React from "react";
+import { Typography, IconButton, Grid } from "@material-ui/core";
+import { useTranslation } from "react-i18next";
+import TxList from "../TxList";
+import { ArrowBackIos, ArrowForwardIos } from "@material-ui/icons";
+
+export interface IProps {
+  transactions: any[];
+  from: number;
+  to: number;
+  disableNext?: boolean;
+  disablePrev?: boolean;
+  onNext?: () => void;
+  onPrev?: () => void;
+  style?: any;
+}
+
+const AddressTransactions: React.FC<IProps> = (props) => {
+  const { t } = useTranslation();
+  return (
+    <div style={props.style}>
+      <Grid container justify="flex-end">
+        <IconButton onClick={props.onPrev} disabled={props.disablePrev}>
+          <ArrowBackIos />
+        </IconButton>
+        <IconButton onClick={props.onNext} disabled={props.disableNext}>
+          <ArrowForwardIos />
+        </IconButton>
+      </Grid>
+      <Grid container justify="flex-end">
+        <Typography>Showing block range: {props.to} - {props.from}</Typography>
+      </Grid>
+      <TxList transactions={props.transactions || []} showBlockNumber={true}></TxList>
+      {(!props.transactions || props.transactions.length === 0) &&
+        <Grid container style={{padding: "15px"}}>
+          <Typography>{t("No Transactions for this block range.")}</Typography>
+        </Grid>
+      }
+    </div>
+  );
+};
+
+export default AddressTransactions;

--- a/src/components/AddressTransactions/index.ts
+++ b/src/components/AddressTransactions/index.ts
@@ -1,0 +1,2 @@
+import AddressTransactions from "./AddressTransactions";
+export default AddressTransactions;

--- a/src/components/BlockList/BlockList.tsx
+++ b/src/components/BlockList/BlockList.tsx
@@ -1,7 +1,7 @@
-import { Table, TableBody, TableCell, TableHead, TableRow, Typography } from "@material-ui/core";
+import { Table, TableBody, TableCell, TableHead, TableRow, Typography, LinearProgress } from "@material-ui/core";
 import * as React from "react";
 import Link from "@material-ui/core/Link";
-import { hexToDate } from "@etclabscore/eserialize";
+import { hexToDate, hexToNumber } from "@etclabscore/eserialize";
 import { Link as RouterLink } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 
@@ -26,10 +26,12 @@ function BlockList({ blocks }: any) {
             <TableCell><Typography>{t("Hash")}</Typography></TableCell>
             <TableCell><Typography>{t("Timestamp")}</Typography></TableCell>
             <TableCell><Typography>{t("Transactions")}</Typography></TableCell>
+            <TableCell><Typography>{t("Gas Used")}</Typography></TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
           {sortedBlocks.map((b: any) => {
+            const filledPercent = (hexToNumber(b.gasUsed) / hexToNumber(b.gasLimit)) * 100;
             return (
               <TableRow key={b.number}>
                 <TableCell component="th" scope="row"><Typography>{parseInt(b.number, 16)}</Typography></TableCell>
@@ -44,10 +46,13 @@ function BlockList({ blocks }: any) {
                   </Link>
                 </TableCell>
                 <TableCell style={rightPaddingFix}>
-                  <Typography>{t("Timestamp Date", { date: hexToDate(b.timestamp)})}</Typography>
+                  <Typography>{t("Timestamp Date", { date: hexToDate(b.timestamp) })}</Typography>
                 </TableCell>
                 <TableCell style={rightPaddingFix}>
                   <Typography>{b.transactions.length}</Typography>
+                </TableCell>
+                <TableCell style={rightPaddingFix}>
+                  <LinearProgress value={filledPercent} variant="determinate" />
                 </TableCell>
               </TableRow>
             );

--- a/src/components/BlockList/BlockList.tsx
+++ b/src/components/BlockList/BlockList.tsx
@@ -26,7 +26,7 @@ function BlockList({ blocks }: any) {
             <TableCell><Typography>{t("Hash")}</Typography></TableCell>
             <TableCell><Typography>{t("Timestamp")}</Typography></TableCell>
             <TableCell><Typography>{t("Transactions")}</Typography></TableCell>
-            <TableCell><Typography>{t("Gas Used")}</Typography></TableCell>
+            <TableCell><Typography>{t("Gas Usage")}</Typography></TableCell>
           </TableRow>
         </TableHead>
         <TableBody>

--- a/src/components/BlockView/BlockView.tsx
+++ b/src/components/BlockView/BlockView.tsx
@@ -6,7 +6,7 @@ import { hexToDate, hexToString, hexToNumber } from "@etclabscore/eserialize";
 import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";
 
-import { Table, TableBody, TableCell, TableRow, Button } from "@material-ui/core";
+import { Table, TableBody, TableCell, TableRow, Button, LinearProgress, Typography } from "@material-ui/core";
 
 function BlockView(props: any) {
   const { block } = props;
@@ -23,6 +23,8 @@ function BlockView(props: any) {
     gasUsed, gasLimit, size,
   } = block;
 
+  const filledPercent = (hexToNumber(gasUsed) / hexToNumber(gasLimit)) * 100;
+
   return (
     <div>
       <Button
@@ -36,6 +38,14 @@ function BlockView(props: any) {
           <TableRow>
             <TableCell>{t("Number")}</TableCell>
             <TableCell>{hexToNumber(block.number)}</TableCell>
+          </TableRow>
+
+          <TableRow>
+            <TableCell>{t("Gas Usage")}</TableCell>
+            <TableCell>
+              <Typography variant="caption">{hexToNumber(gasUsed)}/{hexToNumber(gasLimit)}</Typography>
+              <LinearProgress style={{width: "150px"}} value={filledPercent} variant="determinate" />
+            </TableCell>
           </TableRow>
 
           <TableRow>

--- a/src/components/TxList/TxList.tsx
+++ b/src/components/TxList/TxList.tsx
@@ -60,7 +60,7 @@ function TxList(props: ITxListProps) {
     <Table>
       <TableHead>
         <TableRow>
-          {props.showBlockNumber && <TableCell>Block #</TableCell>}
+          {props.showBlockNumber && <TableCell>Block Number</TableCell>}
           <TableCell>Hash</TableCell>
           <TableCell>From</TableCell>
           <TableCell>To</TableCell>

--- a/src/components/TxList/TxList.tsx
+++ b/src/components/TxList/TxList.tsx
@@ -5,13 +5,11 @@ import Link from "@material-ui/core/Link";
 import { Table, TableBody, TableCell, TableHead, TableRow } from "@material-ui/core";
 import { hexToNumber } from "@etclabscore/eserialize";
 
-export interface ITxListProps {
-  transactions: any[];
-}
-
-function TxListItem({ tx }: { tx: any }) {
+function TxListItem({ tx, showblockNumber }: { tx: any, showblockNumber?: boolean }) {
   return (
     <TableRow>
+      {showblockNumber && <TableCell>{hexToNumber(tx.blockNumber)}</TableCell>}
+
       <TableCell>
         <Link
           component={({ className, children }: { children: any, className: string }) => (
@@ -52,11 +50,17 @@ function TxListItem({ tx }: { tx: any }) {
   );
 }
 
+export interface ITxListProps {
+  transactions: any[];
+  showBlockNumber?: boolean;
+}
+
 function TxList(props: ITxListProps) {
   return (
     <Table>
       <TableHead>
         <TableRow>
+          {props.showBlockNumber && <TableCell>Block #</TableCell>}
           <TableCell>Hash</TableCell>
           <TableCell>From</TableCell>
           <TableCell>To</TableCell>
@@ -65,7 +69,10 @@ function TxList(props: ITxListProps) {
       </TableHead>
 
       <TableBody>
-        {props.transactions.map((tx: any) => <TxListItem key={tx.hash} tx={tx} />)}
+        {props.transactions.map(
+          (tx: any) =>
+            <TxListItem key={tx.hash} tx={tx} showblockNumber={props.showBlockNumber} />,
+        )}
       </TableBody>
     </Table>
   );

--- a/src/containers/Address.tsx
+++ b/src/containers/Address.tsx
@@ -1,20 +1,53 @@
 import { CircularProgress } from "@material-ui/core";
 import * as React from "react";
 import AddressView from "../components/AddressView";
-import { useBlockNumber } from "../helpers";
+import _ from "lodash";
+import getBlocks, { useBlockNumber } from "../helpers";
 import useMultiGethStore from "../stores/useMultiGethStore";
 import EthereumJSONRPC from "@etclabscore/ethereum-json-rpc";
 import { hexToNumber } from "@etclabscore/eserialize";
-
+import AddressTransactions from "../components/AddressTransactions";
+import { History } from "history";
 const unit = require("ethjs-unit"); //tslint:disable-line
 
-export default function Address({ match }: { match: { params: { address: string } } }) {
-  const { address } = match.params;
+interface IUrlParams {
+  number: string | undefined;
+}
+
+interface IProps {
+  match: {
+    params: {
+      address: string,
+      block: string,
+    };
+  };
+  history: History;
+}
+
+const Address: React.FC<IProps> = ({ match, history }) => {
+  const { address, block } = match.params;
   const [erpc]: [EthereumJSONRPC] = useMultiGethStore();
   const [blockNumber] = useBlockNumber(erpc);
   const [transactionCount, setTransactionCount] = React.useState();
   const [balance, setBalance] = React.useState();
   const [code, setCode] = React.useState();
+  const blockNum = block !== undefined ? parseInt(block, 10) : blockNumber;
+  const [transactions, setTransactions] = React.useState();
+
+  const from = Math.max(blockNum - 99, 0);
+  const to = blockNum;
+
+  React.useEffect(() => {
+    if (blockNum === undefined || blockNumber === undefined) {
+      return;
+    }
+    if (blockNum > blockNumber) {
+      history.push(`/address/${address}/${blockNumber}`);
+    }
+    if (blockNum < 0) {
+      history.push(`/address/${address}/0`);
+    }
+  }, [blockNumber, blockNum, history, address]);
 
   React.useEffect(() => {
     if (blockNumber === undefined || !erpc) {
@@ -25,6 +58,24 @@ export default function Address({ match }: { match: { params: { address: string 
     erpc.eth_getBalance(address, hexBlockNumber).then(setBalance);
     erpc.eth_getCode(address, hexBlockNumber).then(setCode);
   }, [blockNumber, address, erpc]);
+
+  React.useEffect(() => {
+    if (!erpc) { return; }
+    getBlocks(from, to, erpc).then((blcks) => {
+      const txes = _.flatMap(blcks, "transactions");
+      const filteredTxes = _.filter(txes, (tx: any) => {
+        if (!tx) {
+          return false;
+        }
+        return tx.to === address || tx.from === address;
+      });
+      const sortedTxes = _.sortBy(filteredTxes, (tx: any) => {
+        return hexToNumber(tx.blockNumber);
+      }).reverse();
+      setTransactions(sortedTxes);
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [from, to]);
 
   if (transactionCount === undefined || balance === undefined || code === undefined) {
     return <CircularProgress />;
@@ -37,6 +88,23 @@ export default function Address({ match }: { match: { params: { address: string 
         balance={unit.fromWei(balance || 0, "ether")}
         code={code}
       />
+      <AddressTransactions
+        from={from}
+        to={to}
+        transactions={transactions}
+        disablePrev={blockNum >= blockNumber}
+        disableNext={blockNum === 0}
+        onPrev={() => {
+          const newQuery = blockNum + 100;
+          history.push(`/address/${address}/${newQuery}`);
+        }}
+        onNext={() => {
+          const newQuery = Math.max(blockNum - 100, 0);
+          history.push(`/address/${address}/${newQuery}`);
+        }}
+      />
     </>
   );
-}
+};
+
+export default Address;

--- a/src/translations/cn.ts
+++ b/src/translations/cn.ts
@@ -57,6 +57,7 @@ export default {
   "Address": "地址",
   "Balance": "余额",
   "Code": "代码",
+  "No Transactions for this block range.": "No Transactions for this block range.",
   // configuration menu
   "Configuration": "配置",
   "Back": "返回",

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -48,6 +48,7 @@ export default {
   "Transaction Index": "Transaction Index",
   "Receipt Status": "Receipt Status",
   "Receipt Logs": "Receipt Logs",
+  "No Transactions for this block range.": "No Transactions for this block range.",
   "Address": "Address",
   "Balance": "Balance",
   "Code": "Code",

--- a/src/translations/kr.ts
+++ b/src/translations/kr.ts
@@ -54,6 +54,7 @@ export default {
   "Receipt Status": "수신상태",
   "Receipt Logs": "수신일지",
   // address view
+  "No Transactions for this block range.": "No Transactions for this block range.",
   "Address": "주소",
   "Balance": "잔액",
   "Code": "코드",


### PR DESCRIPTION
adds paginated transactions list to to the address page

![image](https://user-images.githubusercontent.com/364566/72041596-ddf08c80-3260-11ea-8040-0b63d29725ba.png)

fixes #220

adds gas usage meters for blocks

![image](https://user-images.githubusercontent.com/364566/72041622-ee086c00-3260-11ea-92dc-ad7a5ad90b11.png)
![image](https://user-images.githubusercontent.com/364566/72041691-16906600-3261-11ea-934c-379e76cb8ca3.png)


fixes #207




