### PR TITLE
fix: showing blocks on dashboard with low block numbers

### DIFF
--- a/src/containers/Dashboard.tsx
+++ b/src/containers/Dashboard.tsx
@@ -140,9 +140,9 @@ export default (props: any) => {
 
       <BlockListContainer
         from={Math.max(blockNumber - 14, 0)}
-        to={blockNumber - 3}
+        to={blockNumber}
         disablePrev={true}
-        disableNext={blockNumber === 0}
+        disableNext={blockNumber < 14}
         onNext={() => {
           props.history.push(`/blocks/${blockNumber - 15}`);
         }}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/364566/75387667-85b92c80-5898-11ea-964b-57ee8e251c25.png)

fixes #267 